### PR TITLE
Add parameter parsing options for tool inputs

### DIFF
--- a/bruinen/pyproject.toml
+++ b/bruinen/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bruinen"
-version = "1.1"
+version = "1.2"
 description = "A client library for accessing Bruinen API"
 authors = []
 readme = "README.md"

--- a/bruinen/src/bruinen/client/api/sources/google_controller_parsed_drafts.py
+++ b/bruinen/src/bruinen/client/api/sources/google_controller_parsed_drafts.py
@@ -1,0 +1,191 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.google_parsed_drafts import GoogleParsedDrafts
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Dict[str, Any]:
+    url = "{}/sources/google/parsedDrafts".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["q"] = q
+
+    params["pageToken"] = page_token
+
+    params["accountId"] = account_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[GoogleParsedDrafts]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = GoogleParsedDrafts.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[GoogleParsedDrafts]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedDrafts]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedDrafts]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        account_id=account_id,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedDrafts]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedDrafts
+    """
+
+    return sync_detailed(
+        client=client,
+        q=q,
+        page_token=page_token,
+        account_id=account_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedDrafts]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedDrafts]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        account_id=account_id,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedDrafts]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedDrafts
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            q=q,
+            page_token=page_token,
+            account_id=account_id,
+        )
+    ).parsed

--- a/bruinen/src/bruinen/client/api/sources/google_controller_parsed_messages.py
+++ b/bruinen/src/bruinen/client/api/sources/google_controller_parsed_messages.py
@@ -1,0 +1,206 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.google_parsed_messages import GoogleParsedMessages
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Dict[str, Any]:
+    url = "{}/sources/google/parsedMessages".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["q"] = q
+
+    params["pageToken"] = page_token
+
+    params["labelIds"] = label_ids
+
+    params["accountId"] = account_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[GoogleParsedMessages]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = GoogleParsedMessages.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[GoogleParsedMessages]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedMessages]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedMessages]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedMessages]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedMessages
+    """
+
+    return sync_detailed(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedMessages]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedMessages]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedMessages]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedMessages
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            q=q,
+            page_token=page_token,
+            label_ids=label_ids,
+            account_id=account_id,
+        )
+    ).parsed

--- a/bruinen/src/bruinen/client/api/sources/google_controller_parsed_threads.py
+++ b/bruinen/src/bruinen/client/api/sources/google_controller_parsed_threads.py
@@ -1,0 +1,206 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.google_parsed_threads import GoogleParsedThreads
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Dict[str, Any]:
+    url = "{}/sources/google/parsedThreads".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["q"] = q
+
+    params["pageToken"] = page_token
+
+    params["labelIds"] = label_ids
+
+    params["accountId"] = account_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[GoogleParsedThreads]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = GoogleParsedThreads.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[GoogleParsedThreads]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedThreads]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedThreads]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedThreads]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedThreads
+    """
+
+    return sync_detailed(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Response[GoogleParsedThreads]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[GoogleParsedThreads]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        q=q,
+        page_token=page_token,
+        label_ids=label_ids,
+        account_id=account_id,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    q: Union[Unset, None, str] = UNSET,
+    page_token: Union[Unset, None, str] = UNSET,
+    label_ids: Union[Unset, None, str] = UNSET,
+    account_id: str,
+) -> Optional[GoogleParsedThreads]:
+    """
+    Args:
+        q (Union[Unset, None, str]):
+        page_token (Union[Unset, None, str]):
+        label_ids (Union[Unset, None, str]):
+        account_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        GoogleParsedThreads
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            q=q,
+            page_token=page_token,
+            label_ids=label_ids,
+            account_id=account_id,
+        )
+    ).parsed

--- a/bruinen/src/bruinen/client/models/__init__.py
+++ b/bruinen/src/bruinen/client/models/__init__.py
@@ -128,6 +128,14 @@ from .google_parsed_draft_headers_bcc_item import GoogleParsedDraftHeadersBccIte
 from .google_parsed_draft_headers_cc_item import GoogleParsedDraftHeadersCcItem
 from .google_parsed_draft_headers_from import GoogleParsedDraftHeadersFrom
 from .google_parsed_draft_headers_to_item import GoogleParsedDraftHeadersToItem
+from .google_parsed_drafts import GoogleParsedDrafts
+from .google_parsed_drafts_drafts_item import GoogleParsedDraftsDraftsItem
+from .google_parsed_drafts_drafts_item_attachments_item import GoogleParsedDraftsDraftsItemAttachmentsItem
+from .google_parsed_drafts_drafts_item_headers import GoogleParsedDraftsDraftsItemHeaders
+from .google_parsed_drafts_drafts_item_headers_bcc_item import GoogleParsedDraftsDraftsItemHeadersBccItem
+from .google_parsed_drafts_drafts_item_headers_cc_item import GoogleParsedDraftsDraftsItemHeadersCcItem
+from .google_parsed_drafts_drafts_item_headers_from import GoogleParsedDraftsDraftsItemHeadersFrom
+from .google_parsed_drafts_drafts_item_headers_to_item import GoogleParsedDraftsDraftsItemHeadersToItem
 from .google_parsed_message import GoogleParsedMessage
 from .google_parsed_message_attachments_item import GoogleParsedMessageAttachmentsItem
 from .google_parsed_message_headers import GoogleParsedMessageHeaders
@@ -135,6 +143,14 @@ from .google_parsed_message_headers_bcc_item import GoogleParsedMessageHeadersBc
 from .google_parsed_message_headers_cc_item import GoogleParsedMessageHeadersCcItem
 from .google_parsed_message_headers_from import GoogleParsedMessageHeadersFrom
 from .google_parsed_message_headers_to_item import GoogleParsedMessageHeadersToItem
+from .google_parsed_messages import GoogleParsedMessages
+from .google_parsed_messages_messages_item import GoogleParsedMessagesMessagesItem
+from .google_parsed_messages_messages_item_attachments_item import GoogleParsedMessagesMessagesItemAttachmentsItem
+from .google_parsed_messages_messages_item_headers import GoogleParsedMessagesMessagesItemHeaders
+from .google_parsed_messages_messages_item_headers_bcc_item import GoogleParsedMessagesMessagesItemHeadersBccItem
+from .google_parsed_messages_messages_item_headers_cc_item import GoogleParsedMessagesMessagesItemHeadersCcItem
+from .google_parsed_messages_messages_item_headers_from import GoogleParsedMessagesMessagesItemHeadersFrom
+from .google_parsed_messages_messages_item_headers_to_item import GoogleParsedMessagesMessagesItemHeadersToItem
 from .google_parsed_thread import GoogleParsedThread
 from .google_parsed_thread_messages_item import GoogleParsedThreadMessagesItem
 from .google_parsed_thread_messages_item_attachments_item import GoogleParsedThreadMessagesItemAttachmentsItem
@@ -143,6 +159,25 @@ from .google_parsed_thread_messages_item_headers_bcc_item import GoogleParsedThr
 from .google_parsed_thread_messages_item_headers_cc_item import GoogleParsedThreadMessagesItemHeadersCcItem
 from .google_parsed_thread_messages_item_headers_from import GoogleParsedThreadMessagesItemHeadersFrom
 from .google_parsed_thread_messages_item_headers_to_item import GoogleParsedThreadMessagesItemHeadersToItem
+from .google_parsed_threads import GoogleParsedThreads
+from .google_parsed_threads_threads_item import GoogleParsedThreadsThreadsItem
+from .google_parsed_threads_threads_item_messages_item import GoogleParsedThreadsThreadsItemMessagesItem
+from .google_parsed_threads_threads_item_messages_item_attachments_item import (
+    GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem,
+)
+from .google_parsed_threads_threads_item_messages_item_headers import GoogleParsedThreadsThreadsItemMessagesItemHeaders
+from .google_parsed_threads_threads_item_messages_item_headers_bcc_item import (
+    GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem,
+)
+from .google_parsed_threads_threads_item_messages_item_headers_cc_item import (
+    GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem,
+)
+from .google_parsed_threads_threads_item_messages_item_headers_from import (
+    GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom,
+)
+from .google_parsed_threads_threads_item_messages_item_headers_to_item import (
+    GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem,
+)
 from .google_profile import GoogleProfile
 from .google_thread import GoogleThread
 from .google_thread_messages_item import GoogleThreadMessagesItem
@@ -282,6 +317,14 @@ __all__ = (
     "GoogleParsedDraftHeadersCcItem",
     "GoogleParsedDraftHeadersFrom",
     "GoogleParsedDraftHeadersToItem",
+    "GoogleParsedDrafts",
+    "GoogleParsedDraftsDraftsItem",
+    "GoogleParsedDraftsDraftsItemAttachmentsItem",
+    "GoogleParsedDraftsDraftsItemHeaders",
+    "GoogleParsedDraftsDraftsItemHeadersBccItem",
+    "GoogleParsedDraftsDraftsItemHeadersCcItem",
+    "GoogleParsedDraftsDraftsItemHeadersFrom",
+    "GoogleParsedDraftsDraftsItemHeadersToItem",
     "GoogleParsedMessage",
     "GoogleParsedMessageAttachmentsItem",
     "GoogleParsedMessageHeaders",
@@ -289,6 +332,14 @@ __all__ = (
     "GoogleParsedMessageHeadersCcItem",
     "GoogleParsedMessageHeadersFrom",
     "GoogleParsedMessageHeadersToItem",
+    "GoogleParsedMessages",
+    "GoogleParsedMessagesMessagesItem",
+    "GoogleParsedMessagesMessagesItemAttachmentsItem",
+    "GoogleParsedMessagesMessagesItemHeaders",
+    "GoogleParsedMessagesMessagesItemHeadersBccItem",
+    "GoogleParsedMessagesMessagesItemHeadersCcItem",
+    "GoogleParsedMessagesMessagesItemHeadersFrom",
+    "GoogleParsedMessagesMessagesItemHeadersToItem",
     "GoogleParsedThread",
     "GoogleParsedThreadMessagesItem",
     "GoogleParsedThreadMessagesItemAttachmentsItem",
@@ -297,6 +348,15 @@ __all__ = (
     "GoogleParsedThreadMessagesItemHeadersCcItem",
     "GoogleParsedThreadMessagesItemHeadersFrom",
     "GoogleParsedThreadMessagesItemHeadersToItem",
+    "GoogleParsedThreads",
+    "GoogleParsedThreadsThreadsItem",
+    "GoogleParsedThreadsThreadsItemMessagesItem",
+    "GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem",
+    "GoogleParsedThreadsThreadsItemMessagesItemHeaders",
+    "GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem",
+    "GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem",
+    "GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom",
+    "GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem",
     "GoogleProfile",
     "GoogleThread",
     "GoogleThreadMessagesItem",

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts.py
@@ -1,0 +1,92 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_drafts_drafts_item import GoogleParsedDraftsDraftsItem
+
+
+T = TypeVar("T", bound="GoogleParsedDrafts")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDrafts:
+    """Your google parsed drafts
+
+    Attributes:
+        drafts (Union[Unset, List['GoogleParsedDraftsDraftsItem']]): A list of your google drafts
+        next_page_token (Union[Unset, str]): The next page token for your drafts
+        result_size_estimate (Union[Unset, float]): The result size estimate for your drafts
+    """
+
+    drafts: Union[Unset, List["GoogleParsedDraftsDraftsItem"]] = UNSET
+    next_page_token: Union[Unset, str] = UNSET
+    result_size_estimate: Union[Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        drafts: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.drafts, Unset):
+            drafts = []
+            for drafts_item_data in self.drafts:
+                drafts_item = drafts_item_data.to_dict()
+
+                drafts.append(drafts_item)
+
+        next_page_token = self.next_page_token
+        result_size_estimate = self.result_size_estimate
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if drafts is not UNSET:
+            field_dict["drafts"] = drafts
+        if next_page_token is not UNSET:
+            field_dict["nextPageToken"] = next_page_token
+        if result_size_estimate is not UNSET:
+            field_dict["resultSizeEstimate"] = result_size_estimate
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_drafts_drafts_item import GoogleParsedDraftsDraftsItem
+
+        d = src_dict.copy()
+        drafts = []
+        _drafts = d.pop("drafts", UNSET) or UNSET
+        for drafts_item_data in _drafts or []:
+            drafts_item = GoogleParsedDraftsDraftsItem.from_dict(drafts_item_data)
+
+            drafts.append(drafts_item)
+
+        next_page_token = d.pop("nextPageToken", UNSET) or UNSET
+
+        result_size_estimate = d.pop("resultSizeEstimate", UNSET) or UNSET
+
+        google_parsed_drafts = cls(
+            drafts=drafts,
+            next_page_token=next_page_token,
+            result_size_estimate=result_size_estimate,
+        )
+
+        google_parsed_drafts.additional_properties = d
+        return google_parsed_drafts
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item.py
@@ -1,0 +1,137 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_drafts_drafts_item_attachments_item import GoogleParsedDraftsDraftsItemAttachmentsItem
+    from ..models.google_parsed_drafts_drafts_item_headers import GoogleParsedDraftsDraftsItemHeaders
+
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItem:
+    """
+    Attributes:
+        id (Union[Unset, str]): The id of the draft
+        message_id (Union[Unset, str]): The id of the draft
+        thread_id (Union[Unset, str]): The threadId of the draft
+        label_ids (Union[Unset, List[str]]): The labelIds of the draft
+        headers (Union[Unset, GoogleParsedDraftsDraftsItemHeaders]): The headers of the draft
+        body (Union[Unset, str]): The body of the draft
+        attachments (Union[Unset, List['GoogleParsedDraftsDraftsItemAttachmentsItem']]): The attachments of the draft
+    """
+
+    id: Union[Unset, str] = UNSET
+    message_id: Union[Unset, str] = UNSET
+    thread_id: Union[Unset, str] = UNSET
+    label_ids: Union[Unset, List[str]] = UNSET
+    headers: Union[Unset, "GoogleParsedDraftsDraftsItemHeaders"] = UNSET
+    body: Union[Unset, str] = UNSET
+    attachments: Union[Unset, List["GoogleParsedDraftsDraftsItemAttachmentsItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        message_id = self.message_id
+        thread_id = self.thread_id
+        label_ids: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.label_ids, Unset):
+            label_ids = self.label_ids
+
+        headers: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.headers, Unset):
+            headers = self.headers.to_dict()
+
+        body = self.body
+        attachments: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.attachments, Unset):
+            attachments = []
+            for attachments_item_data in self.attachments:
+                attachments_item = attachments_item_data.to_dict()
+
+                attachments.append(attachments_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if message_id is not UNSET:
+            field_dict["messageId"] = message_id
+        if thread_id is not UNSET:
+            field_dict["threadId"] = thread_id
+        if label_ids is not UNSET:
+            field_dict["labelIds"] = label_ids
+        if headers is not UNSET:
+            field_dict["headers"] = headers
+        if body is not UNSET:
+            field_dict["body"] = body
+        if attachments is not UNSET:
+            field_dict["attachments"] = attachments
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_drafts_drafts_item_attachments_item import (
+            GoogleParsedDraftsDraftsItemAttachmentsItem,
+        )
+        from ..models.google_parsed_drafts_drafts_item_headers import GoogleParsedDraftsDraftsItemHeaders
+
+        d = src_dict.copy()
+        id = d.pop("id", UNSET) or UNSET
+
+        message_id = d.pop("messageId", UNSET) or UNSET
+
+        thread_id = d.pop("threadId", UNSET) or UNSET
+
+        label_ids = cast(List[str], d.pop("labelIds", UNSET) or UNSET)
+
+        _headers = d.pop("headers", UNSET) or UNSET
+        headers: Union[Unset, GoogleParsedDraftsDraftsItemHeaders]
+        if isinstance(_headers, Unset):
+            headers = UNSET
+        else:
+            headers = GoogleParsedDraftsDraftsItemHeaders.from_dict(_headers)
+
+        body = d.pop("body", UNSET) or UNSET
+
+        attachments = []
+        _attachments = d.pop("attachments", UNSET) or UNSET
+        for attachments_item_data in _attachments or []:
+            attachments_item = GoogleParsedDraftsDraftsItemAttachmentsItem.from_dict(attachments_item_data)
+
+            attachments.append(attachments_item)
+
+        google_parsed_drafts_drafts_item = cls(
+            id=id,
+            message_id=message_id,
+            thread_id=thread_id,
+            label_ids=label_ids,
+            headers=headers,
+            body=body,
+            attachments=attachments,
+        )
+
+        google_parsed_drafts_drafts_item.additional_properties = d
+        return google_parsed_drafts_drafts_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_attachments_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_attachments_item.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemAttachmentsItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemAttachmentsItem:
+    """An attachment of the draft
+
+    Attributes:
+        attachment_id (Union[Unset, str]): The attachmentId of the attachment
+        mime_type (Union[Unset, str]): The mimeType of the attachment
+        filename (Union[Unset, str]): The filename of the attachment
+        content_type (Union[Unset, str]): The contentType of the attachment
+        content_disposition (Union[Unset, str]): The contentDisposition of the attachment
+        content_transfer_encoding (Union[Unset, str]): The contentTransferEncoding of the attachment
+        size (Union[Unset, float]): The size of the attachment
+    """
+
+    attachment_id: Union[Unset, str] = UNSET
+    mime_type: Union[Unset, str] = UNSET
+    filename: Union[Unset, str] = UNSET
+    content_type: Union[Unset, str] = UNSET
+    content_disposition: Union[Unset, str] = UNSET
+    content_transfer_encoding: Union[Unset, str] = UNSET
+    size: Union[Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        attachment_id = self.attachment_id
+        mime_type = self.mime_type
+        filename = self.filename
+        content_type = self.content_type
+        content_disposition = self.content_disposition
+        content_transfer_encoding = self.content_transfer_encoding
+        size = self.size
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if attachment_id is not UNSET:
+            field_dict["attachmentId"] = attachment_id
+        if mime_type is not UNSET:
+            field_dict["mimeType"] = mime_type
+        if filename is not UNSET:
+            field_dict["filename"] = filename
+        if content_type is not UNSET:
+            field_dict["contentType"] = content_type
+        if content_disposition is not UNSET:
+            field_dict["contentDisposition"] = content_disposition
+        if content_transfer_encoding is not UNSET:
+            field_dict["contentTransferEncoding"] = content_transfer_encoding
+        if size is not UNSET:
+            field_dict["size"] = size
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        attachment_id = d.pop("attachmentId", UNSET) or UNSET
+
+        mime_type = d.pop("mimeType", UNSET) or UNSET
+
+        filename = d.pop("filename", UNSET) or UNSET
+
+        content_type = d.pop("contentType", UNSET) or UNSET
+
+        content_disposition = d.pop("contentDisposition", UNSET) or UNSET
+
+        content_transfer_encoding = d.pop("contentTransferEncoding", UNSET) or UNSET
+
+        size = d.pop("size", UNSET) or UNSET
+
+        google_parsed_drafts_drafts_item_attachments_item = cls(
+            attachment_id=attachment_id,
+            mime_type=mime_type,
+            filename=filename,
+            content_type=content_type,
+            content_disposition=content_disposition,
+            content_transfer_encoding=content_transfer_encoding,
+            size=size,
+        )
+
+        google_parsed_drafts_drafts_item_attachments_item.additional_properties = d
+        return google_parsed_drafts_drafts_item_attachments_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers.py
@@ -1,0 +1,155 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_drafts_drafts_item_headers_bcc_item import GoogleParsedDraftsDraftsItemHeadersBccItem
+    from ..models.google_parsed_drafts_drafts_item_headers_cc_item import GoogleParsedDraftsDraftsItemHeadersCcItem
+    from ..models.google_parsed_drafts_drafts_item_headers_from import GoogleParsedDraftsDraftsItemHeadersFrom
+    from ..models.google_parsed_drafts_drafts_item_headers_to_item import GoogleParsedDraftsDraftsItemHeadersToItem
+
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemHeaders")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemHeaders:
+    """The headers of the draft
+
+    Attributes:
+        date (Union[Unset, str]): The date of the draft
+        subject (Union[Unset, str]): The subject of the draft
+        from_ (Union[Unset, GoogleParsedDraftsDraftsItemHeadersFrom]): The writer of the draft
+        to (Union[Unset, List['GoogleParsedDraftsDraftsItemHeadersToItem']]): The receivers of the draft
+        cc (Union[Unset, List['GoogleParsedDraftsDraftsItemHeadersCcItem']]): The ccs of the draft
+        bcc (Union[Unset, List['GoogleParsedDraftsDraftsItemHeadersBccItem']]): The bccs of the draft
+    """
+
+    date: Union[Unset, str] = UNSET
+    subject: Union[Unset, str] = UNSET
+    from_: Union[Unset, "GoogleParsedDraftsDraftsItemHeadersFrom"] = UNSET
+    to: Union[Unset, List["GoogleParsedDraftsDraftsItemHeadersToItem"]] = UNSET
+    cc: Union[Unset, List["GoogleParsedDraftsDraftsItemHeadersCcItem"]] = UNSET
+    bcc: Union[Unset, List["GoogleParsedDraftsDraftsItemHeadersBccItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        date = self.date
+        subject = self.subject
+        from_: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.from_, Unset):
+            from_ = self.from_.to_dict()
+
+        to: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.to, Unset):
+            to = []
+            for to_item_data in self.to:
+                to_item = to_item_data.to_dict()
+
+                to.append(to_item)
+
+        cc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.cc, Unset):
+            cc = []
+            for cc_item_data in self.cc:
+                cc_item = cc_item_data.to_dict()
+
+                cc.append(cc_item)
+
+        bcc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.bcc, Unset):
+            bcc = []
+            for bcc_item_data in self.bcc:
+                bcc_item = bcc_item_data.to_dict()
+
+                bcc.append(bcc_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if date is not UNSET:
+            field_dict["date"] = date
+        if subject is not UNSET:
+            field_dict["subject"] = subject
+        if from_ is not UNSET:
+            field_dict["from"] = from_
+        if to is not UNSET:
+            field_dict["to"] = to
+        if cc is not UNSET:
+            field_dict["cc"] = cc
+        if bcc is not UNSET:
+            field_dict["bcc"] = bcc
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_drafts_drafts_item_headers_bcc_item import (
+            GoogleParsedDraftsDraftsItemHeadersBccItem,
+        )
+        from ..models.google_parsed_drafts_drafts_item_headers_cc_item import GoogleParsedDraftsDraftsItemHeadersCcItem
+        from ..models.google_parsed_drafts_drafts_item_headers_from import GoogleParsedDraftsDraftsItemHeadersFrom
+        from ..models.google_parsed_drafts_drafts_item_headers_to_item import GoogleParsedDraftsDraftsItemHeadersToItem
+
+        d = src_dict.copy()
+        date = d.pop("date", UNSET) or UNSET
+
+        subject = d.pop("subject", UNSET) or UNSET
+
+        _from_ = d.pop("from", UNSET) or UNSET
+        from_: Union[Unset, GoogleParsedDraftsDraftsItemHeadersFrom]
+        if isinstance(_from_, Unset):
+            from_ = UNSET
+        else:
+            from_ = GoogleParsedDraftsDraftsItemHeadersFrom.from_dict(_from_)
+
+        to = []
+        _to = d.pop("to", UNSET) or UNSET
+        for to_item_data in _to or []:
+            to_item = GoogleParsedDraftsDraftsItemHeadersToItem.from_dict(to_item_data)
+
+            to.append(to_item)
+
+        cc = []
+        _cc = d.pop("cc", UNSET) or UNSET
+        for cc_item_data in _cc or []:
+            cc_item = GoogleParsedDraftsDraftsItemHeadersCcItem.from_dict(cc_item_data)
+
+            cc.append(cc_item)
+
+        bcc = []
+        _bcc = d.pop("bcc", UNSET) or UNSET
+        for bcc_item_data in _bcc or []:
+            bcc_item = GoogleParsedDraftsDraftsItemHeadersBccItem.from_dict(bcc_item_data)
+
+            bcc.append(bcc_item)
+
+        google_parsed_drafts_drafts_item_headers = cls(
+            date=date,
+            subject=subject,
+            from_=from_,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+        )
+
+        google_parsed_drafts_drafts_item_headers.additional_properties = d
+        return google_parsed_drafts_drafts_item_headers
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_bcc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_bcc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemHeadersBccItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemHeadersBccItem:
+    """A bcc of the draft
+
+    Attributes:
+        name (Union[Unset, str]): The name of the bcc
+        email (Union[Unset, str]): The email of the bcc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_drafts_drafts_item_headers_bcc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_drafts_drafts_item_headers_bcc_item.additional_properties = d
+        return google_parsed_drafts_drafts_item_headers_bcc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_cc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_cc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemHeadersCcItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemHeadersCcItem:
+    """A cc of the draft
+
+    Attributes:
+        name (Union[Unset, str]): The name of the cc
+        email (Union[Unset, str]): The email of the cc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_drafts_drafts_item_headers_cc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_drafts_drafts_item_headers_cc_item.additional_properties = d
+        return google_parsed_drafts_drafts_item_headers_cc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_from.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_from.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemHeadersFrom")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemHeadersFrom:
+    """The writer of the draft
+
+    Attributes:
+        name (Union[Unset, str]): The name of the writer
+        email (Union[Unset, str]): The email of the writer
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_drafts_drafts_item_headers_from = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_drafts_drafts_item_headers_from.additional_properties = d
+        return google_parsed_drafts_drafts_item_headers_from
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_to_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_drafts_drafts_item_headers_to_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedDraftsDraftsItemHeadersToItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedDraftsDraftsItemHeadersToItem:
+    """A recipients of the draft
+
+    Attributes:
+        name (Union[Unset, str]): The name of the recipient
+        email (Union[Unset, str]): The email of the recipient
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_drafts_drafts_item_headers_to_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_drafts_drafts_item_headers_to_item.additional_properties = d
+        return google_parsed_drafts_drafts_item_headers_to_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages.py
@@ -1,0 +1,91 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_messages_messages_item import GoogleParsedMessagesMessagesItem
+
+
+T = TypeVar("T", bound="GoogleParsedMessages")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessages:
+    """Your google parsed messages
+
+    Attributes:
+        result_size_estimate (Union[Unset, float]): The result size estimate for your messages
+        next_page_token (Union[Unset, str]): The next page token
+        messages (Union[Unset, List['GoogleParsedMessagesMessagesItem']]): A list of your google messages
+    """
+
+    result_size_estimate: Union[Unset, float] = UNSET
+    next_page_token: Union[Unset, str] = UNSET
+    messages: Union[Unset, List["GoogleParsedMessagesMessagesItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        result_size_estimate = self.result_size_estimate
+        next_page_token = self.next_page_token
+        messages: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.messages, Unset):
+            messages = []
+            for messages_item_data in self.messages:
+                messages_item = messages_item_data.to_dict()
+
+                messages.append(messages_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if result_size_estimate is not UNSET:
+            field_dict["resultSizeEstimate"] = result_size_estimate
+        if next_page_token is not UNSET:
+            field_dict["nextPageToken"] = next_page_token
+        if messages is not UNSET:
+            field_dict["messages"] = messages
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_messages_messages_item import GoogleParsedMessagesMessagesItem
+
+        d = src_dict.copy()
+        result_size_estimate = d.pop("resultSizeEstimate", UNSET) or UNSET
+
+        next_page_token = d.pop("nextPageToken", UNSET) or UNSET
+
+        messages = []
+        _messages = d.pop("messages", UNSET) or UNSET
+        for messages_item_data in _messages or []:
+            messages_item = GoogleParsedMessagesMessagesItem.from_dict(messages_item_data)
+
+            messages.append(messages_item)
+
+        google_parsed_messages = cls(
+            result_size_estimate=result_size_estimate,
+            next_page_token=next_page_token,
+            messages=messages,
+        )
+
+        google_parsed_messages.additional_properties = d
+        return google_parsed_messages
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item.py
@@ -1,0 +1,132 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_messages_messages_item_attachments_item import (
+        GoogleParsedMessagesMessagesItemAttachmentsItem,
+    )
+    from ..models.google_parsed_messages_messages_item_headers import GoogleParsedMessagesMessagesItemHeaders
+
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItem:
+    """
+    Attributes:
+        id (Union[Unset, str]): The id of the message
+        thread_id (Union[Unset, str]): The threadId of the message
+        label_ids (Union[Unset, List[str]]): The labelIds of the message
+        headers (Union[Unset, GoogleParsedMessagesMessagesItemHeaders]): The headers of the message
+        body (Union[Unset, str]): The body of the message
+        attachments (Union[Unset, List['GoogleParsedMessagesMessagesItemAttachmentsItem']]): The attachments of the
+            message
+    """
+
+    id: Union[Unset, str] = UNSET
+    thread_id: Union[Unset, str] = UNSET
+    label_ids: Union[Unset, List[str]] = UNSET
+    headers: Union[Unset, "GoogleParsedMessagesMessagesItemHeaders"] = UNSET
+    body: Union[Unset, str] = UNSET
+    attachments: Union[Unset, List["GoogleParsedMessagesMessagesItemAttachmentsItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        thread_id = self.thread_id
+        label_ids: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.label_ids, Unset):
+            label_ids = self.label_ids
+
+        headers: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.headers, Unset):
+            headers = self.headers.to_dict()
+
+        body = self.body
+        attachments: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.attachments, Unset):
+            attachments = []
+            for attachments_item_data in self.attachments:
+                attachments_item = attachments_item_data.to_dict()
+
+                attachments.append(attachments_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if thread_id is not UNSET:
+            field_dict["threadId"] = thread_id
+        if label_ids is not UNSET:
+            field_dict["labelIds"] = label_ids
+        if headers is not UNSET:
+            field_dict["headers"] = headers
+        if body is not UNSET:
+            field_dict["body"] = body
+        if attachments is not UNSET:
+            field_dict["attachments"] = attachments
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_messages_messages_item_attachments_item import (
+            GoogleParsedMessagesMessagesItemAttachmentsItem,
+        )
+        from ..models.google_parsed_messages_messages_item_headers import GoogleParsedMessagesMessagesItemHeaders
+
+        d = src_dict.copy()
+        id = d.pop("id", UNSET) or UNSET
+
+        thread_id = d.pop("threadId", UNSET) or UNSET
+
+        label_ids = cast(List[str], d.pop("labelIds", UNSET) or UNSET)
+
+        _headers = d.pop("headers", UNSET) or UNSET
+        headers: Union[Unset, GoogleParsedMessagesMessagesItemHeaders]
+        if isinstance(_headers, Unset):
+            headers = UNSET
+        else:
+            headers = GoogleParsedMessagesMessagesItemHeaders.from_dict(_headers)
+
+        body = d.pop("body", UNSET) or UNSET
+
+        attachments = []
+        _attachments = d.pop("attachments", UNSET) or UNSET
+        for attachments_item_data in _attachments or []:
+            attachments_item = GoogleParsedMessagesMessagesItemAttachmentsItem.from_dict(attachments_item_data)
+
+            attachments.append(attachments_item)
+
+        google_parsed_messages_messages_item = cls(
+            id=id,
+            thread_id=thread_id,
+            label_ids=label_ids,
+            headers=headers,
+            body=body,
+            attachments=attachments,
+        )
+
+        google_parsed_messages_messages_item.additional_properties = d
+        return google_parsed_messages_messages_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_attachments_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_attachments_item.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemAttachmentsItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemAttachmentsItem:
+    """An attachment of the message
+
+    Attributes:
+        attachment_id (Union[Unset, str]): The attachmentId of the attachment
+        mime_type (Union[Unset, str]): The mimeType of the attachment
+        filename (Union[Unset, str]): The filename of the attachment
+        content_type (Union[Unset, str]): The contentType of the attachment
+        content_disposition (Union[Unset, str]): The contentDisposition of the attachment
+        content_transfer_encoding (Union[Unset, str]): The contentTransferEncoding of the attachment
+        size (Union[Unset, float]): The size of the attachment
+    """
+
+    attachment_id: Union[Unset, str] = UNSET
+    mime_type: Union[Unset, str] = UNSET
+    filename: Union[Unset, str] = UNSET
+    content_type: Union[Unset, str] = UNSET
+    content_disposition: Union[Unset, str] = UNSET
+    content_transfer_encoding: Union[Unset, str] = UNSET
+    size: Union[Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        attachment_id = self.attachment_id
+        mime_type = self.mime_type
+        filename = self.filename
+        content_type = self.content_type
+        content_disposition = self.content_disposition
+        content_transfer_encoding = self.content_transfer_encoding
+        size = self.size
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if attachment_id is not UNSET:
+            field_dict["attachmentId"] = attachment_id
+        if mime_type is not UNSET:
+            field_dict["mimeType"] = mime_type
+        if filename is not UNSET:
+            field_dict["filename"] = filename
+        if content_type is not UNSET:
+            field_dict["contentType"] = content_type
+        if content_disposition is not UNSET:
+            field_dict["contentDisposition"] = content_disposition
+        if content_transfer_encoding is not UNSET:
+            field_dict["contentTransferEncoding"] = content_transfer_encoding
+        if size is not UNSET:
+            field_dict["size"] = size
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        attachment_id = d.pop("attachmentId", UNSET) or UNSET
+
+        mime_type = d.pop("mimeType", UNSET) or UNSET
+
+        filename = d.pop("filename", UNSET) or UNSET
+
+        content_type = d.pop("contentType", UNSET) or UNSET
+
+        content_disposition = d.pop("contentDisposition", UNSET) or UNSET
+
+        content_transfer_encoding = d.pop("contentTransferEncoding", UNSET) or UNSET
+
+        size = d.pop("size", UNSET) or UNSET
+
+        google_parsed_messages_messages_item_attachments_item = cls(
+            attachment_id=attachment_id,
+            mime_type=mime_type,
+            filename=filename,
+            content_type=content_type,
+            content_disposition=content_disposition,
+            content_transfer_encoding=content_transfer_encoding,
+            size=size,
+        )
+
+        google_parsed_messages_messages_item_attachments_item.additional_properties = d
+        return google_parsed_messages_messages_item_attachments_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers.py
@@ -1,0 +1,167 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_messages_messages_item_headers_bcc_item import (
+        GoogleParsedMessagesMessagesItemHeadersBccItem,
+    )
+    from ..models.google_parsed_messages_messages_item_headers_cc_item import (
+        GoogleParsedMessagesMessagesItemHeadersCcItem,
+    )
+    from ..models.google_parsed_messages_messages_item_headers_from import GoogleParsedMessagesMessagesItemHeadersFrom
+    from ..models.google_parsed_messages_messages_item_headers_to_item import (
+        GoogleParsedMessagesMessagesItemHeadersToItem,
+    )
+
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemHeaders")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemHeaders:
+    """The headers of the message
+
+    Attributes:
+        date (Union[Unset, str]): The date of the message
+        subject (Union[Unset, str]): The subject of the message
+        from_ (Union[Unset, GoogleParsedMessagesMessagesItemHeadersFrom]): The writer of the message
+        to (Union[Unset, List['GoogleParsedMessagesMessagesItemHeadersToItem']]): The receivers of the message
+        cc (Union[Unset, List['GoogleParsedMessagesMessagesItemHeadersCcItem']]): The ccs of the message
+        bcc (Union[Unset, List['GoogleParsedMessagesMessagesItemHeadersBccItem']]): The bccs of the message
+    """
+
+    date: Union[Unset, str] = UNSET
+    subject: Union[Unset, str] = UNSET
+    from_: Union[Unset, "GoogleParsedMessagesMessagesItemHeadersFrom"] = UNSET
+    to: Union[Unset, List["GoogleParsedMessagesMessagesItemHeadersToItem"]] = UNSET
+    cc: Union[Unset, List["GoogleParsedMessagesMessagesItemHeadersCcItem"]] = UNSET
+    bcc: Union[Unset, List["GoogleParsedMessagesMessagesItemHeadersBccItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        date = self.date
+        subject = self.subject
+        from_: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.from_, Unset):
+            from_ = self.from_.to_dict()
+
+        to: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.to, Unset):
+            to = []
+            for to_item_data in self.to:
+                to_item = to_item_data.to_dict()
+
+                to.append(to_item)
+
+        cc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.cc, Unset):
+            cc = []
+            for cc_item_data in self.cc:
+                cc_item = cc_item_data.to_dict()
+
+                cc.append(cc_item)
+
+        bcc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.bcc, Unset):
+            bcc = []
+            for bcc_item_data in self.bcc:
+                bcc_item = bcc_item_data.to_dict()
+
+                bcc.append(bcc_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if date is not UNSET:
+            field_dict["date"] = date
+        if subject is not UNSET:
+            field_dict["subject"] = subject
+        if from_ is not UNSET:
+            field_dict["from"] = from_
+        if to is not UNSET:
+            field_dict["to"] = to
+        if cc is not UNSET:
+            field_dict["cc"] = cc
+        if bcc is not UNSET:
+            field_dict["bcc"] = bcc
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_messages_messages_item_headers_bcc_item import (
+            GoogleParsedMessagesMessagesItemHeadersBccItem,
+        )
+        from ..models.google_parsed_messages_messages_item_headers_cc_item import (
+            GoogleParsedMessagesMessagesItemHeadersCcItem,
+        )
+        from ..models.google_parsed_messages_messages_item_headers_from import (
+            GoogleParsedMessagesMessagesItemHeadersFrom,
+        )
+        from ..models.google_parsed_messages_messages_item_headers_to_item import (
+            GoogleParsedMessagesMessagesItemHeadersToItem,
+        )
+
+        d = src_dict.copy()
+        date = d.pop("date", UNSET) or UNSET
+
+        subject = d.pop("subject", UNSET) or UNSET
+
+        _from_ = d.pop("from", UNSET) or UNSET
+        from_: Union[Unset, GoogleParsedMessagesMessagesItemHeadersFrom]
+        if isinstance(_from_, Unset):
+            from_ = UNSET
+        else:
+            from_ = GoogleParsedMessagesMessagesItemHeadersFrom.from_dict(_from_)
+
+        to = []
+        _to = d.pop("to", UNSET) or UNSET
+        for to_item_data in _to or []:
+            to_item = GoogleParsedMessagesMessagesItemHeadersToItem.from_dict(to_item_data)
+
+            to.append(to_item)
+
+        cc = []
+        _cc = d.pop("cc", UNSET) or UNSET
+        for cc_item_data in _cc or []:
+            cc_item = GoogleParsedMessagesMessagesItemHeadersCcItem.from_dict(cc_item_data)
+
+            cc.append(cc_item)
+
+        bcc = []
+        _bcc = d.pop("bcc", UNSET) or UNSET
+        for bcc_item_data in _bcc or []:
+            bcc_item = GoogleParsedMessagesMessagesItemHeadersBccItem.from_dict(bcc_item_data)
+
+            bcc.append(bcc_item)
+
+        google_parsed_messages_messages_item_headers = cls(
+            date=date,
+            subject=subject,
+            from_=from_,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+        )
+
+        google_parsed_messages_messages_item_headers.additional_properties = d
+        return google_parsed_messages_messages_item_headers
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_bcc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_bcc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemHeadersBccItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemHeadersBccItem:
+    """A bcc of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the bcc
+        email (Union[Unset, str]): The email of the bcc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_messages_messages_item_headers_bcc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_messages_messages_item_headers_bcc_item.additional_properties = d
+        return google_parsed_messages_messages_item_headers_bcc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_cc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_cc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemHeadersCcItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemHeadersCcItem:
+    """A cc of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the cc
+        email (Union[Unset, str]): The email of the cc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_messages_messages_item_headers_cc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_messages_messages_item_headers_cc_item.additional_properties = d
+        return google_parsed_messages_messages_item_headers_cc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_from.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_from.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemHeadersFrom")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemHeadersFrom:
+    """The writer of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the writer
+        email (Union[Unset, str]): The email of the writer
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_messages_messages_item_headers_from = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_messages_messages_item_headers_from.additional_properties = d
+        return google_parsed_messages_messages_item_headers_from
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_to_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_messages_messages_item_headers_to_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedMessagesMessagesItemHeadersToItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedMessagesMessagesItemHeadersToItem:
+    """A recipients of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the recipient
+        email (Union[Unset, str]): The email of the recipient
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_messages_messages_item_headers_to_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_messages_messages_item_headers_to_item.additional_properties = d
+        return google_parsed_messages_messages_item_headers_to_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads.py
@@ -1,0 +1,91 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_threads_threads_item import GoogleParsedThreadsThreadsItem
+
+
+T = TypeVar("T", bound="GoogleParsedThreads")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreads:
+    """Your google parsed threads
+
+    Attributes:
+        result_size_estimate (Union[Unset, float]): The result size estimate for your threads
+        next_page_token (Union[Unset, str]): The next page token
+        threads (Union[Unset, List['GoogleParsedThreadsThreadsItem']]): A list of your google threads
+    """
+
+    result_size_estimate: Union[Unset, float] = UNSET
+    next_page_token: Union[Unset, str] = UNSET
+    threads: Union[Unset, List["GoogleParsedThreadsThreadsItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        result_size_estimate = self.result_size_estimate
+        next_page_token = self.next_page_token
+        threads: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.threads, Unset):
+            threads = []
+            for threads_item_data in self.threads:
+                threads_item = threads_item_data.to_dict()
+
+                threads.append(threads_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if result_size_estimate is not UNSET:
+            field_dict["resultSizeEstimate"] = result_size_estimate
+        if next_page_token is not UNSET:
+            field_dict["nextPageToken"] = next_page_token
+        if threads is not UNSET:
+            field_dict["threads"] = threads
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_threads_threads_item import GoogleParsedThreadsThreadsItem
+
+        d = src_dict.copy()
+        result_size_estimate = d.pop("resultSizeEstimate", UNSET) or UNSET
+
+        next_page_token = d.pop("nextPageToken", UNSET) or UNSET
+
+        threads = []
+        _threads = d.pop("threads", UNSET) or UNSET
+        for threads_item_data in _threads or []:
+            threads_item = GoogleParsedThreadsThreadsItem.from_dict(threads_item_data)
+
+            threads.append(threads_item)
+
+        google_parsed_threads = cls(
+            result_size_estimate=result_size_estimate,
+            next_page_token=next_page_token,
+            threads=threads,
+        )
+
+        google_parsed_threads.additional_properties = d
+        return google_parsed_threads
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item.py
@@ -1,0 +1,83 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_threads_threads_item_messages_item import GoogleParsedThreadsThreadsItemMessagesItem
+
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItem:
+    """
+    Attributes:
+        id (Union[Unset, str]): The id of the thread
+        messages (Union[Unset, List['GoogleParsedThreadsThreadsItemMessagesItem']]): A list of the messages in the
+            thread
+    """
+
+    id: Union[Unset, str] = UNSET
+    messages: Union[Unset, List["GoogleParsedThreadsThreadsItemMessagesItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        messages: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.messages, Unset):
+            messages = []
+            for messages_item_data in self.messages:
+                messages_item = messages_item_data.to_dict()
+
+                messages.append(messages_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if messages is not UNSET:
+            field_dict["messages"] = messages
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_threads_threads_item_messages_item import GoogleParsedThreadsThreadsItemMessagesItem
+
+        d = src_dict.copy()
+        id = d.pop("id", UNSET) or UNSET
+
+        messages = []
+        _messages = d.pop("messages", UNSET) or UNSET
+        for messages_item_data in _messages or []:
+            messages_item = GoogleParsedThreadsThreadsItemMessagesItem.from_dict(messages_item_data)
+
+            messages.append(messages_item)
+
+        google_parsed_threads_threads_item = cls(
+            id=id,
+            messages=messages,
+        )
+
+        google_parsed_threads_threads_item.additional_properties = d
+        return google_parsed_threads_threads_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item.py
@@ -1,0 +1,139 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_threads_threads_item_messages_item_attachments_item import (
+        GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem,
+    )
+    from ..models.google_parsed_threads_threads_item_messages_item_headers import (
+        GoogleParsedThreadsThreadsItemMessagesItemHeaders,
+    )
+
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItem:
+    """A message in the thread
+
+    Attributes:
+        id (Union[Unset, str]): The id of the message
+        thread_id (Union[Unset, str]): The threadId of the message
+        label_ids (Union[Unset, List[str]]): The labelIds of the message
+        headers (Union[Unset, GoogleParsedThreadsThreadsItemMessagesItemHeaders]): The headers of the message
+        body (Union[Unset, str]): The body of the message
+        attachments (Union[Unset, List['GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem']]): The attachments
+            of the message
+    """
+
+    id: Union[Unset, str] = UNSET
+    thread_id: Union[Unset, str] = UNSET
+    label_ids: Union[Unset, List[str]] = UNSET
+    headers: Union[Unset, "GoogleParsedThreadsThreadsItemMessagesItemHeaders"] = UNSET
+    body: Union[Unset, str] = UNSET
+    attachments: Union[Unset, List["GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+        thread_id = self.thread_id
+        label_ids: Union[Unset, List[str]] = UNSET
+        if not isinstance(self.label_ids, Unset):
+            label_ids = self.label_ids
+
+        headers: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.headers, Unset):
+            headers = self.headers.to_dict()
+
+        body = self.body
+        attachments: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.attachments, Unset):
+            attachments = []
+            for attachments_item_data in self.attachments:
+                attachments_item = attachments_item_data.to_dict()
+
+                attachments.append(attachments_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if id is not UNSET:
+            field_dict["id"] = id
+        if thread_id is not UNSET:
+            field_dict["threadId"] = thread_id
+        if label_ids is not UNSET:
+            field_dict["labelIds"] = label_ids
+        if headers is not UNSET:
+            field_dict["headers"] = headers
+        if body is not UNSET:
+            field_dict["body"] = body
+        if attachments is not UNSET:
+            field_dict["attachments"] = attachments
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_threads_threads_item_messages_item_attachments_item import (
+            GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem,
+        )
+        from ..models.google_parsed_threads_threads_item_messages_item_headers import (
+            GoogleParsedThreadsThreadsItemMessagesItemHeaders,
+        )
+
+        d = src_dict.copy()
+        id = d.pop("id", UNSET) or UNSET
+
+        thread_id = d.pop("threadId", UNSET) or UNSET
+
+        label_ids = cast(List[str], d.pop("labelIds", UNSET) or UNSET)
+
+        _headers = d.pop("headers", UNSET) or UNSET
+        headers: Union[Unset, GoogleParsedThreadsThreadsItemMessagesItemHeaders]
+        if isinstance(_headers, Unset):
+            headers = UNSET
+        else:
+            headers = GoogleParsedThreadsThreadsItemMessagesItemHeaders.from_dict(_headers)
+
+        body = d.pop("body", UNSET) or UNSET
+
+        attachments = []
+        _attachments = d.pop("attachments", UNSET) or UNSET
+        for attachments_item_data in _attachments or []:
+            attachments_item = GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem.from_dict(
+                attachments_item_data
+            )
+
+            attachments.append(attachments_item)
+
+        google_parsed_threads_threads_item_messages_item = cls(
+            id=id,
+            thread_id=thread_id,
+            label_ids=label_ids,
+            headers=headers,
+            body=body,
+            attachments=attachments,
+        )
+
+        google_parsed_threads_threads_item_messages_item.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_attachments_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_attachments_item.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemAttachmentsItem:
+    """An attachment of the message
+
+    Attributes:
+        attachment_id (Union[Unset, str]): The attachmentId of the attachment
+        mime_type (Union[Unset, str]): The mimeType of the attachment
+        filename (Union[Unset, str]): The filename of the attachment
+        content_type (Union[Unset, str]): The contentType of the attachment
+        content_disposition (Union[Unset, str]): The contentDisposition of the attachment
+        content_transfer_encoding (Union[Unset, str]): The contentTransferEncoding of the attachment
+        size (Union[Unset, float]): The size of the attachment
+    """
+
+    attachment_id: Union[Unset, str] = UNSET
+    mime_type: Union[Unset, str] = UNSET
+    filename: Union[Unset, str] = UNSET
+    content_type: Union[Unset, str] = UNSET
+    content_disposition: Union[Unset, str] = UNSET
+    content_transfer_encoding: Union[Unset, str] = UNSET
+    size: Union[Unset, float] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        attachment_id = self.attachment_id
+        mime_type = self.mime_type
+        filename = self.filename
+        content_type = self.content_type
+        content_disposition = self.content_disposition
+        content_transfer_encoding = self.content_transfer_encoding
+        size = self.size
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if attachment_id is not UNSET:
+            field_dict["attachmentId"] = attachment_id
+        if mime_type is not UNSET:
+            field_dict["mimeType"] = mime_type
+        if filename is not UNSET:
+            field_dict["filename"] = filename
+        if content_type is not UNSET:
+            field_dict["contentType"] = content_type
+        if content_disposition is not UNSET:
+            field_dict["contentDisposition"] = content_disposition
+        if content_transfer_encoding is not UNSET:
+            field_dict["contentTransferEncoding"] = content_transfer_encoding
+        if size is not UNSET:
+            field_dict["size"] = size
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        attachment_id = d.pop("attachmentId", UNSET) or UNSET
+
+        mime_type = d.pop("mimeType", UNSET) or UNSET
+
+        filename = d.pop("filename", UNSET) or UNSET
+
+        content_type = d.pop("contentType", UNSET) or UNSET
+
+        content_disposition = d.pop("contentDisposition", UNSET) or UNSET
+
+        content_transfer_encoding = d.pop("contentTransferEncoding", UNSET) or UNSET
+
+        size = d.pop("size", UNSET) or UNSET
+
+        google_parsed_threads_threads_item_messages_item_attachments_item = cls(
+            attachment_id=attachment_id,
+            mime_type=mime_type,
+            filename=filename,
+            content_type=content_type,
+            content_disposition=content_disposition,
+            content_transfer_encoding=content_transfer_encoding,
+            size=size,
+        )
+
+        google_parsed_threads_threads_item_messages_item_attachments_item.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_attachments_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers.py
@@ -1,0 +1,169 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.google_parsed_threads_threads_item_messages_item_headers_bcc_item import (
+        GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem,
+    )
+    from ..models.google_parsed_threads_threads_item_messages_item_headers_cc_item import (
+        GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem,
+    )
+    from ..models.google_parsed_threads_threads_item_messages_item_headers_from import (
+        GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom,
+    )
+    from ..models.google_parsed_threads_threads_item_messages_item_headers_to_item import (
+        GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem,
+    )
+
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemHeaders")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemHeaders:
+    """The headers of the message
+
+    Attributes:
+        date (Union[Unset, str]): The date of the message
+        subject (Union[Unset, str]): The subject of the message
+        from_ (Union[Unset, GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom]): The writer of the message
+        to (Union[Unset, List['GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem']]): The receivers of the message
+        cc (Union[Unset, List['GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem']]): The ccs of the message
+        bcc (Union[Unset, List['GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem']]): The bccs of the message
+    """
+
+    date: Union[Unset, str] = UNSET
+    subject: Union[Unset, str] = UNSET
+    from_: Union[Unset, "GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom"] = UNSET
+    to: Union[Unset, List["GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem"]] = UNSET
+    cc: Union[Unset, List["GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem"]] = UNSET
+    bcc: Union[Unset, List["GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem"]] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        date = self.date
+        subject = self.subject
+        from_: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.from_, Unset):
+            from_ = self.from_.to_dict()
+
+        to: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.to, Unset):
+            to = []
+            for to_item_data in self.to:
+                to_item = to_item_data.to_dict()
+
+                to.append(to_item)
+
+        cc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.cc, Unset):
+            cc = []
+            for cc_item_data in self.cc:
+                cc_item = cc_item_data.to_dict()
+
+                cc.append(cc_item)
+
+        bcc: Union[Unset, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.bcc, Unset):
+            bcc = []
+            for bcc_item_data in self.bcc:
+                bcc_item = bcc_item_data.to_dict()
+
+                bcc.append(bcc_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if date is not UNSET:
+            field_dict["date"] = date
+        if subject is not UNSET:
+            field_dict["subject"] = subject
+        if from_ is not UNSET:
+            field_dict["from"] = from_
+        if to is not UNSET:
+            field_dict["to"] = to
+        if cc is not UNSET:
+            field_dict["cc"] = cc
+        if bcc is not UNSET:
+            field_dict["bcc"] = bcc
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.google_parsed_threads_threads_item_messages_item_headers_bcc_item import (
+            GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem,
+        )
+        from ..models.google_parsed_threads_threads_item_messages_item_headers_cc_item import (
+            GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem,
+        )
+        from ..models.google_parsed_threads_threads_item_messages_item_headers_from import (
+            GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom,
+        )
+        from ..models.google_parsed_threads_threads_item_messages_item_headers_to_item import (
+            GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem,
+        )
+
+        d = src_dict.copy()
+        date = d.pop("date", UNSET) or UNSET
+
+        subject = d.pop("subject", UNSET) or UNSET
+
+        _from_ = d.pop("from", UNSET) or UNSET
+        from_: Union[Unset, GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom]
+        if isinstance(_from_, Unset):
+            from_ = UNSET
+        else:
+            from_ = GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom.from_dict(_from_)
+
+        to = []
+        _to = d.pop("to", UNSET) or UNSET
+        for to_item_data in _to or []:
+            to_item = GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem.from_dict(to_item_data)
+
+            to.append(to_item)
+
+        cc = []
+        _cc = d.pop("cc", UNSET) or UNSET
+        for cc_item_data in _cc or []:
+            cc_item = GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem.from_dict(cc_item_data)
+
+            cc.append(cc_item)
+
+        bcc = []
+        _bcc = d.pop("bcc", UNSET) or UNSET
+        for bcc_item_data in _bcc or []:
+            bcc_item = GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem.from_dict(bcc_item_data)
+
+            bcc.append(bcc_item)
+
+        google_parsed_threads_threads_item_messages_item_headers = cls(
+            date=date,
+            subject=subject,
+            from_=from_,
+            to=to,
+            cc=cc,
+            bcc=bcc,
+        )
+
+        google_parsed_threads_threads_item_messages_item_headers.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_headers
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_bcc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_bcc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemHeadersBccItem:
+    """A bcc of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the bcc
+        email (Union[Unset, str]): The email of the bcc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_threads_threads_item_messages_item_headers_bcc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_threads_threads_item_messages_item_headers_bcc_item.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_headers_bcc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_cc_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_cc_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemHeadersCcItem:
+    """A cc of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the cc
+        email (Union[Unset, str]): The email of the cc
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_threads_threads_item_messages_item_headers_cc_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_threads_threads_item_messages_item_headers_cc_item.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_headers_cc_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_from.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_from.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemHeadersFrom:
+    """The writer of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the writer
+        email (Union[Unset, str]): The email of the writer
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_threads_threads_item_messages_item_headers_from = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_threads_threads_item_messages_item_headers_from.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_headers_from
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_to_item.py
+++ b/bruinen/src/bruinen/client/models/google_parsed_threads_threads_item_messages_item_headers_to_item.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem")
+
+
+@attr.s(auto_attribs=True)
+class GoogleParsedThreadsThreadsItemMessagesItemHeadersToItem:
+    """A recipients of the message
+
+    Attributes:
+        name (Union[Unset, str]): The name of the recipient
+        email (Union[Unset, str]): The email of the recipient
+    """
+
+    name: Union[Unset, str] = UNSET
+    email: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        email = self.email
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if name is not UNSET:
+            field_dict["name"] = name
+        if email is not UNSET:
+            field_dict["email"] = email
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name", UNSET) or UNSET
+
+        email = d.pop("email", UNSET) or UNSET
+
+        google_parsed_threads_threads_item_messages_item_headers_to_item = cls(
+            name=name,
+            email=email,
+        )
+
+        google_parsed_threads_threads_item_messages_item_headers_to_item.additional_properties = d
+        return google_parsed_threads_threads_item_messages_item_headers_to_item
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/bruinen/src/bruinen/langchain/github.py
+++ b/bruinen/src/bruinen/langchain/github.py
@@ -77,10 +77,10 @@ class GithubGetReposTool(BaseTool):
     client: AuthenticatedClient
     user_id: str
     parse_output: Optional[Callable[[List["GithubRepo"]], str]] = None
-
+    
     def _run(self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None) -> str:
         """Run the tool."""
-
+        
         response: Response[List["ReturnedAccountDto"]] = find_all_accounts_for_user.sync_detailed(
             client=self.client, user_id=self.user_id
         )
@@ -130,10 +130,10 @@ class GithubGetProfileTool(BaseTool):
     client: AuthenticatedClient
     user_id: str
     parse_output: Optional[Callable[[GithubProfile], str]] = None
-
+    
     def _run(self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None) -> str:
         """Run the tool."""
-
+        
         response: Response[List["ReturnedAccountDto"]] = find_all_accounts_for_user.sync_detailed(
             client=self.client, user_id=self.user_id
         )

--- a/langchain_tools_example.py
+++ b/langchain_tools_example.py
@@ -17,12 +17,107 @@ client = AuthenticatedClient(base_url='http://localhost:3000', token=bruinen_sec
 
 ## Authenticator tool example
 
-user_id = '0a40131b-7c8a-4d0b-a2ba-a99e20db31ae'
 
 llm = OpenAI(temperature=0)
-google_auth_tool = GoogleAuthenticatorTool(client=client, user_id=user_id, redirect_url='http://localhost:3000')
-agent = initialize_agent([google_auth_tool], llm, agent='chat-zero-shot-react-description', verbose=True)
-result = agent.run("Authenticate my Google account.")
+
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+from langchain.output_parsers import PydanticOutputParser
+from bruinen.src.bruinen.langchain.google import GoogleGetParsedMessagesTool
+
+def parse_parameters(_query: str) -> GoogleGetParsedMessagesTool.input_schema:
+    # Parse the q parameter
+    _prompt = PromptTemplate(
+        input_variables=["query"],
+        template="""
+        Given the provided input query, output a response that adheres to the following syntax:
+
+        If you want to the specify the sender:
+        from:sender
+        Example: from:amy
+
+        If you want to specify a recipient: 
+        to:recipient
+        Example: to:david
+
+        If you want to specify a recipient who received a cc:
+        cc:recipient
+        Example: cc:david
+
+        If you want to specify a recipient who received a bcc:
+        bcc:recipient
+        Example: bcc:david
+
+        If you want to specify words in the subject line:
+        subject:words
+        Example: subject:dinner
+
+        If you want to specify messages that match multiple terms:
+        term1 OR term2
+        Example: from:amy OR from:david
+
+        If you want to search for an exact word or phrase in the message or subject line:
+        "word or phrase"
+        Example: "dinner and movie tonight"
+        
+        If anything in the input query does not relate to functionality in the above description, do not include it in the response.
+        For example, exlude anything related to page tokens and labels.
+
+        Here is the input query:
+
+        {query}
+        """
+    )
+    q_parser_chain = LLMChain(llm=llm, prompt=_prompt)
+    parsed_q = q_parser_chain.run(query=_query)
+    print('parsed q parameter', parsed_q)
+
+    # Parse all the other parameters except for q
+    parser = PydanticOutputParser(pydantic_object=GoogleGetParsedMessagesTool.input_schema)
+    prompt = PromptTemplate(
+        template="""Parse the provided input string.
+        For values that are not marked as required, if no value is provided, return a null value.
+        {format_instructions}
+        Here is the input:
+        {query}""",
+        input_variables=["query"],
+        partial_variables={"format_instructions": parser.get_format_instructions()},
+    )
+    _input = prompt.format_prompt(query=_query)
+    pydantic_llm = OpenAI(temperature=0)
+    output = pydantic_llm(_input.to_string())
+    params: GoogleGetParsedMessagesTool.input_schema = parser.parse(output)
+    print('params except q', params)
+    params.q = parsed_q.strip()
+
+    print('all params', params)
+
+    return params
+
+
+
+print(parse_parameters("What are my Google messages that are to or from tevon@bruinen.co, and contain with pageToken='1'?"))
+
+user_id = '0a40131b-7c8a-4d0b-a2ba-a99e20db31ae'
+llm = OpenAI(temperature=0)
+
+def parse_output(output, query):
+    print(output)
+    return output
+
+tool = GoogleGetParsedMessagesTool(client=client, user_id=user_id, parse_output=parse_output, parse_parameters=parse_parameters, llm=llm)
+agent = initialize_agent([tool], llm, agent='chat-zero-shot-react-description', verbose=True)
+result = agent.run("What are my Google messages that are to or from tevon@bruinen.co?")
+
+# When creating a tool that has inputs, you'll either:
+# 1. Need to pass a custom parameter parser function that will parse the input string into the correct format
+# 2. Pass an LLM that will be used in the default parser
+
+# How to deal with page tokens?
+# We will need to do sequential calls to the Google API if we want to get all of the results
+# This will likely need to be custom tool functionality, as we'll need to keep track of the page tokens and 
+# keep calling the API until there's no next one
+
 
 exit()
 

--- a/langchain_tools_example.py
+++ b/langchain_tools_example.py
@@ -15,8 +15,7 @@ from bruinen.src.bruinen.client import AuthenticatedClient
 
 client = AuthenticatedClient(base_url='http://localhost:3000', token=bruinen_secret, prefix='', auth_header_name='X-API-Key')
 
-## Authenticator tool example
-
+# Google parsed drafts example
 
 llm = OpenAI(temperature=0)
 
@@ -62,6 +61,7 @@ def parse_parameters(_query: str) -> GoogleGetParsedMessagesTool.input_schema:
         
         If anything in the input query does not relate to functionality in the above description, do not include it in the response.
         For example, exlude anything related to page tokens and labels.
+        If no response is necessary for the input query, respond with an empty string.
 
         Here is the input query:
 
@@ -70,54 +70,113 @@ def parse_parameters(_query: str) -> GoogleGetParsedMessagesTool.input_schema:
     )
     q_parser_chain = LLMChain(llm=llm, prompt=_prompt)
     parsed_q = q_parser_chain.run(query=_query)
-    print('parsed q parameter', parsed_q)
 
-    # Parse all the other parameters except for q
-    parser = PydanticOutputParser(pydantic_object=GoogleGetParsedMessagesTool.input_schema)
-    prompt = PromptTemplate(
-        template="""Parse the provided input string.
-        For values that are not marked as required, if no value is provided, return a null value.
-        {format_instructions}
-        Here is the input:
-        {query}""",
-        input_variables=["query"],
-        partial_variables={"format_instructions": parser.get_format_instructions()},
-    )
-    _input = prompt.format_prompt(query=_query)
-    pydantic_llm = OpenAI(temperature=0)
-    output = pydantic_llm(_input.to_string())
-    params: GoogleGetParsedMessagesTool.input_schema = parser.parse(output)
-    print('params except q', params)
+    # For now, we'll ignore the labelId and pageToken parameters
+    params = GoogleGetParsedMessagesTool.input_schema()
+    print(parsed_q)
     params.q = parsed_q.strip()
 
-    print('all params', params)
-
     return params
-
-
-
-print(parse_parameters("What are my Google messages that are to or from tevon@bruinen.co, and contain with pageToken='1'?"))
 
 user_id = '0a40131b-7c8a-4d0b-a2ba-a99e20db31ae'
 llm = OpenAI(temperature=0)
 
-def parse_output(output, query):
-    print(output)
-    return output
+from bruinen.src.bruinen.client.models import GoogleParsedMessages, GoogleParsedMessage, GoogleParsedMessagesMessagesItem
+from bruinen.src.bruinen.langchain.parsers import SQLParser
+from typing import List, Dict, Any
+from pydantic import Field
+from datetime import datetime
+
+def parse_output(output: GoogleParsedMessages, query: str):
+    messages: List["GoogleParsedMessagesMessagesItem"] = output.messages
+
+    # Get a usable table from the messages
+    class MessagesItem:
+        from_name: str = Field(description="The name of the sender")
+        from_email: str = Field(description="The email of the sender")
+        date_time: datetime = Field(description="The date and time the message was sent")
+        to_emails: List[str] = Field(description="The emails of the recipients")
+        cc_emails: List[str] = Field(description="The emails of the recipients who received a cc")
+        bcc_emails: List[str] = Field(description="The emails of the recipients who received a bcc")
+        subject: str = Field(description="The subject of the message")
+        body: str = Field(description="The body of the message")
+        
+        def __init__(self, from_name, from_email, date_time, subject, body, to_emails, cc_emails, bcc_emails):
+            self.from_name = from_name
+            self.from_email = from_email
+            self.date_time = date_time
+            self.subject = subject
+            self.body = body
+            self.to_emails = to_emails
+            self.cc_emails = cc_emails
+            self.bcc_emails = bcc_emails
+
+        def to_dict(self) -> Dict[str, Any]:
+            fields = {}
+            fields['from_name'] = self.from_name
+            fields['from_email'] = self.from_email
+            fields['date_time'] = self.date_time
+            fields['subject'] = self.subject
+            fields['body'] = self.body
+            fields['to_emails'] = self.to_emails
+            fields['cc_emails'] = self.cc_emails
+            fields['bcc_emails'] = self.bcc_emails
+            return fields
+
+    parsed_messages: List["MessagesItem"] = []
+
+    for m in messages:
+        message = m.to_dict()
+        if 'name' in message['headers']['from'].keys():
+            from_name = message['headers']['from']['name']
+        else:
+            from_name = ''
+        from_email = message['headers']['from']['email']
+        date_time_str = message['headers']['date']
+        if "(" in date_time_str:
+            date_time_str = date_time_str[:date_time_str.index("(")].strip()
+        date_format = "%a, %d %b %Y %H:%M:%S %z"
+        date_time = datetime.strptime(date_time_str, date_format)
+        if 'subject' in message['headers'].keys():
+            subject = message['headers']['subject']
+        else:
+            subject = ''
+        if 'body' in message.keys():
+            body = message['body']
+        else:
+            body = ''
+        to_emails = []
+        for recipient in message['headers']['to']:
+            to_emails.append(recipient['email'])
+        cc_emails = []
+        for cc in message['headers']['cc']:
+            cc_emails.append(cc['email'])
+        bcc_emails = []
+        for bcc in message['headers']['bcc']:
+            bcc_emails.append(bcc['email'])
+
+        parsed_message = MessagesItem(
+            from_name = from_name,
+            from_email = from_email,
+            date_time = date_time,
+            subject = subject,
+            body = body,
+            to_emails = to_emails,
+            cc_emails = cc_emails,
+            bcc_emails = bcc_emails
+        )
+
+        parsed_messages.append(parsed_message)
+
+    llm = OpenAI(temperature=0)
+    parser = SQLParser(llm=llm)
+    result = parser.parse(parsed_messages, query)
+
+    return result
 
 tool = GoogleGetParsedMessagesTool(client=client, user_id=user_id, parse_output=parse_output, parse_parameters=parse_parameters, llm=llm)
 agent = initialize_agent([tool], llm, agent='chat-zero-shot-react-description', verbose=True)
-result = agent.run("What are my Google messages that are to or from tevon@bruinen.co?")
-
-# When creating a tool that has inputs, you'll either:
-# 1. Need to pass a custom parameter parser function that will parse the input string into the correct format
-# 2. Pass an LLM that will be used in the default parser
-
-# How to deal with page tokens?
-# We will need to do sequential calls to the Google API if we want to get all of the results
-# This will likely need to be custom tool functionality, as we'll need to keep track of the page tokens and 
-# keep calling the API until there's no next one
-
+result = agent.run("What is the body of the most recent message that is either to or from tevon@bruinen.co?")
 
 exit()
 

--- a/langchain_tools_example.py
+++ b/langchain_tools_example.py
@@ -31,36 +31,36 @@ def parse_parameters(_query: str) -> GoogleGetParsedMessagesTool.input_schema:
         template="""
         Given the provided input query, output a response that adheres to the following syntax:
 
-        If you want to the specify the sender:
+        To the specify the sender:
         from:sender
         Example: from:amy
 
-        If you want to specify a recipient: 
+        To specify a recipient: 
         to:recipient
         Example: to:david
 
-        If you want to specify a recipient who received a cc:
+        To specify a recipient who received a cc:
         cc:recipient
         Example: cc:david
 
-        If you want to specify a recipient who received a bcc:
+        To specify a recipient who received a bcc:
         bcc:recipient
         Example: bcc:david
 
-        If you want to specify words in the subject line:
+        To specify words in the subject line:
         subject:words
         Example: subject:dinner
 
-        If you want to specify messages that match multiple terms:
+        To specify messages that match multiple terms:
         term1 OR term2
         Example: from:amy OR from:david
 
-        If you want to search for an exact word or phrase in the message or subject line:
+        To search for an exact word or phrase in the message or subject line:
         "word or phrase"
         Example: "dinner and movie tonight"
         
         If anything in the input query does not relate to functionality in the above description, do not include it in the response.
-        For example, exlude anything related to page tokens and labels.
+        Exclude anything related to page tokens and labels.
         If no response is necessary for the input query, respond with an empty string.
 
         Here is the input query:

--- a/templates/source_template.jinja2
+++ b/templates/source_template.jinja2
@@ -74,20 +74,20 @@ class {{ resource.class_name }}(BaseTool):
     Output will be the text response from the {{ source_name.title() }} API.
     """
 
-    client: AuthenticatedClient
-    {% if resource.has_parameters %}llm: BaseLanguageModel
-    {% endif %}user_id: str
+    {% if resource.has_parameters %}class {{ resource.class_name + "InputSchema" }}(BaseModel):
+        {% for parameter in resource.parameters %}{{ parameter.name }}: {% if not parameter.required %}Optional[{% endif %}{{ parameter.python_type }}{% if not parameter.required %}]{% endif %} = Field(description="{{ parameter.description }}")
+        {% endfor %}
+    input_schema = {{ resource.class_name + "InputSchema" }}
+
+    {% endif %}client: AuthenticatedClient
+    user_id: str{% if resource.has_parameters %}
+    llm: Optional[BaseLanguageModel]
+    parse_parameters: Optional[Callable[[str], {{ resource.class_name + "InputSchema" }}]] = None{% endif %}
     parse_output: Optional[Callable[[{% if resource.is_array %}List["{{ resource.output_model_name }}"]{% else %}{{ resource.output_model_name }}{% endif %}], str]] = None
-
-    def _run(self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None) -> str:
-        """Run the tool."""
-
-        {% if resource.has_parameters %}class {{ resource.class_name + "InputSchema" }}(BaseModel):
-            {% for parameter in resource.parameters %}{{ parameter.name }}: {% if not parameter.required %}Optional[{% endif %}{{ parameter.python_type }}{% if not parameter.required %}]{% endif %} = Field(description="{{ parameter.description }}")
-            {% endfor %}
-        
-        parser = PydanticOutputParser(pydantic_object={{ resource.class_name + "InputSchema" }})
-        
+    
+    {% if resource.has_parameters %}def _parse_parameters(self, _query: str) -> {{ resource.class_name + "InputSchema" }}:
+        """Parse the input passed to the tool when running."""
+        parser = PydanticOutputParser(pydantic_object=self.{{ resource.class_name + "InputSchema" }})
         prompt = PromptTemplate(
             template="""Parse the provided input string.
             For values that are not marked as required, if no value is provided, return a null value.
@@ -97,10 +97,20 @@ class {{ resource.class_name }}(BaseTool):
             input_variables=["query"],
             partial_variables={"format_instructions": parser.get_format_instructions()},
         )
-
-        _input = prompt.format_prompt(query=query)
+        _input = prompt.format_prompt(query=_query)
+        if self.llm is None:
+            return "Error: No language model provided for input parsing."
         output = self.llm(_input.to_string())
-        parsed_parameters = parser.parse(output)
+        return parser.parse(output)
+    
+    {% endif %}def _run(self, query: str, run_manager: Optional[CallbackManagerForToolRun] = None) -> str:
+        """Run the tool."""
+        
+        {% if resource.has_parameters %}# If no custom input parameter parser is passed, use the default one
+        if self.parse_parameters is None:
+            parsed_parameters = self._parse_parameters(query)
+        else: 
+            parsed_parameters = self.parse_parameters(query)
         
         {% endif %}response: Response[List["ReturnedAccountDto"]] = find_all_accounts_for_user.sync_detailed(
             client=self.client, user_id=self.user_id


### PR DESCRIPTION
@tevonsb take a look. Some of these changes are just adding the new parsed resource tools, but the changes to The Google/Github tools are what will be used from now on.

Essentially, for any resource that has input parameters needed for the API, the client has the option to:

1. Use the default input parser (defined as `_parse_parameters` in each tool). This will require that they pass an LLM on tool creation for use in the function.
2. Pass their own input parsing function using `parse_parameters` on tool creation. This allows for flexibility in how the input is parsed. The passed parsing must return a Pydantic object that matches the `tool.input_schema` model